### PR TITLE
Add known_hosts table

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -37,3 +37,15 @@ CREATE TABLE IF NOT EXISTS ssh_keys(
     FOREIGN KEY (user_id) REFERENCES users(id),
     unique (user_id, filename)
 );
+
+CREATE TABLE IF NOT EXISTS known_hosts(
+    id uuid DEFAULT uuid_generate_v4() NOT NULL,
+    user_id uuid NOT NULL,
+    host_pattern VARCHAR(1024) NOT NULL,
+    key_type VARCHAR(255) NOT NULL,
+    key_data TEXT NOT NULL,
+    marker VARCHAR(64) NOT NULL DEFAULT '',
+    PRIMARY KEY (id),
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    UNIQUE (user_id, host_pattern, key_type)
+);

--- a/migrations/21-add-known-hosts.sql
+++ b/migrations/21-add-known-hosts.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS known_hosts(
+    id uuid DEFAULT uuid_generate_v4() NOT NULL,
+    user_id uuid NOT NULL,
+    host_pattern VARCHAR(1024) NOT NULL,
+    key_type VARCHAR(255) NOT NULL,
+    key_data TEXT NOT NULL,
+    marker VARCHAR(64) NOT NULL DEFAULT '',
+    PRIMARY KEY (id),
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    UNIQUE (user_id, host_pattern, key_type)
+);


### PR DESCRIPTION
## Summary

- Adds `known_hosts` table with columns `id`, `user_id`, `host_pattern`, `key_type`, `key_data`, and `marker`
- Unique constraint on `(user_id, host_pattern, key_type)` enables UPSERT merge across machines
- Added to both `init.sql` (for fresh installs) and `migrations/21-add-known-hosts.sql`

Closes https://github.com/therealpaulgg/ssh-sync/issues/53