### PR TITLE
Add migrations for master key rotation

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS machines(
     user_id uuid NOT NULL,
     name VARCHAR(255) NOT NULL,
     public_key BYTEA not null,
+    encapsulation_key BYTEA,
     PRIMARY KEY (id),
     FOREIGN KEY (user_id) REFERENCES users(id),
     unique (user_id, name)
@@ -48,4 +49,12 @@ CREATE TABLE IF NOT EXISTS known_hosts(
     PRIMARY KEY (id),
     FOREIGN KEY (user_id) REFERENCES users(id),
     UNIQUE (user_id, host_pattern, key_type)
+);
+
+CREATE TABLE IF NOT EXISTS master_key_rotations(
+    id uuid DEFAULT uuid_generate_v4() NOT NULL PRIMARY KEY,
+    machine_id uuid NOT NULL REFERENCES machines(id) ON DELETE CASCADE,
+    encrypted_master_key BYTEA NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT (now() AT TIME ZONE 'UTC'),
+    UNIQUE (machine_id)
 );

--- a/migrations/22-add-encapsulation-key-to-machines.sql
+++ b/migrations/22-add-encapsulation-key-to-machines.sql
@@ -1,0 +1,1 @@
+ALTER TABLE machines ADD COLUMN encapsulation_key BYTEA;

--- a/migrations/23-add-master-key-rotations.sql
+++ b/migrations/23-add-master-key-rotations.sql
@@ -1,0 +1,7 @@
+CREATE TABLE master_key_rotations (
+    id uuid DEFAULT uuid_generate_v4() NOT NULL PRIMARY KEY,
+    machine_id uuid NOT NULL REFERENCES machines(id) ON DELETE CASCADE,
+    encrypted_master_key BYTEA NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT (now() AT TIME ZONE 'UTC'),
+    UNIQUE (machine_id)
+);


### PR DESCRIPTION
## Summary

- Migration 22: `ALTER TABLE machines ADD COLUMN encapsulation_key BYTEA` — stores the ML-KEM-768 encapsulation key for each machine, used to encrypt the master key with post-quantum KEM during rotation.
- Migration 23: `CREATE TABLE master_key_rotations (machine_id, encrypted_master_key, created_at)` with `UNIQUE(machine_id)` — tracks pending per-machine master key rotations distributed after a `rotate-master-key` run.

## Test plan

- [ ] Apply migrations against a running Postgres instance and verify both columns/tables exist with correct constraints.
- [ ] Confirm `UNIQUE(machine_id)` on `master_key_rotations` allows upsert (on-conflict update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)